### PR TITLE
CMake: Add CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 3.5)
+project(jabcode C)
+
+include(GNUInstallDirs)
+
+set(CMAKE_C_STANDARD 11)
+
+if(NOT WIN32)
+    find_library(M_LIB m)
+endif()
+
+find_package(TIFF)
+find_package(PNG)
+
+if(NOT TIFF_FOUND)
+    message(WARNING "libtiff not found, will probably end in an error\n"
+                    "Try installing libtiff-dev or similar from your package manager")
+endif()
+if(NOT PNG_FOUND)
+    message(WARNING "libpng not found, will probably end in an error\n"
+                    "Try installing libpng-dev or similar from your package manager")
+endif()
+
+add_library(jabcode
+    src/jabcode/binarizer.c
+    src/jabcode/decoder.c
+    src/jabcode/decoder.h
+    src/jabcode/detector.c
+    src/jabcode/detector.h
+    src/jabcode/encoder.c
+    src/jabcode/encoder.h
+    src/jabcode/image.c
+    src/jabcode/include/jabcode.h
+    src/jabcode/interleave.c
+    src/jabcode/ldpc.c
+    src/jabcode/ldpc.h
+    src/jabcode/mask.c
+    src/jabcode/pseudo_random.c
+    src/jabcode/pseudo_random.h
+    src/jabcode/sample.c
+    src/jabcode/transform.c)
+
+target_link_libraries(jabcode PUBLIC
+    PNG::PNG
+    TIFF::TIFF
+    ${M_LIB})
+target_include_directories(jabcode PUBLIC
+    src/jabcode/include
+    ${PNG_INCLUDE_DIRS}
+    ${TIFF_INCLUDE_DIR})
+
+add_executable(jabcodeReader
+    src/jabcodeReader/jabreader.c)
+target_link_libraries(jabcodeReader PRIVATE
+    jabcode)
+
+add_executable(jabcodeWriter
+    src/jabcodeWriter/jabwriter.c
+    src/jabcodeWriter/jabwriter.h)
+target_link_libraries(jabcodeWriter PRIVATE
+    jabcode)
+
+install(TARGETS jabcode jabcodeReader jabcodeWriter
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install(FILES src/jabcode/include/jabcode.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
Allows for easy building using cmake and a generator of the builder's choosing

Can generate Unix Makefiles or Visual Studio sln through the -G parameter
(`-G"Unix Makefiles"` or `-G"Visual Studio 16 2019" -A x64`)

example using Ninja (Another Makefile like system)

```bash
cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
cmake --build build --target install
```

CMake 3.5(.1) was chosen due it being available by default on Ubuntu 16.04

An alternative CMake version that can be targeted is 2.8.12(.2) since that is what is available on Centos 6.10 and Ubuntu 14.04 by default.
Although this is not recommended due to how old that is and also the lack of features it will have.
Plus the docs for cmake < 3.0 are hard to get to in general